### PR TITLE
style: Adjust settings drawer spacing

### DIFF
--- a/packages/nextjs/components/burnerwallet/SettingsDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/SettingsDrawer.tsx
@@ -37,7 +37,7 @@ export const SettingsDrawer = () => {
 
   return (
     <Drawer direction="left">
-      <DrawerTrigger className="btn btn-sm btn-ghost text-white">
+      <DrawerTrigger className="px-1 btn btn-sm btn-ghost text-white">
         <Cog6ToothIcon className="w-6" />
       </DrawerTrigger>
       <DrawerContent className="flex flex-col h-full w-[85%] md:w-[400px] fixed bottom-0 left-0 rounded-tl-none">
@@ -47,7 +47,7 @@ export const SettingsDrawer = () => {
           </DrawerClose>
           <DrawerTitle className="m-0 text-xl md:text-2xl">Settings</DrawerTitle>
         </DrawerHeader>
-        <div className="flex flex-col gap-2 px-6">
+        <div className="flex flex-col gap-2 px-6 mt-1">
           <div className="flex items-center justify-between">
             Dark Mode <SwitchTheme />
           </div>


### PR DESCRIPTION
## Description

I noticed on my phone that the settings drawer is a bit cramped when the Private Key warning is open. Added some simple style adjustments to tighten up the drawer, mainly putting the `<` back button and the `Settings` title on the same row.

## Screenshots

<img width="449" alt="Screenshot 2024-04-13 at 4 46 13 PM" src="https://github.com/BuidlGuidl/burnerwallet/assets/716376/4e72fac1-13b7-4af8-b8d7-1c2e68c6052d">
