### PR TITLE
Save current network to local storage

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
+import { useLocalStorage } from "usehooks-ts";
 import { useAccount, useNetwork, useSwitchNetwork } from "wagmi";
 import { NetworksDropdown } from "~~/components/NetworksDropdown";
 import { ReceiveDrawer } from "~~/components/burnerwallet/ReceiveDrawer";
 import { SendDrawer } from "~~/components/burnerwallet/SendDrawer";
 import { SettingsDrawer } from "~~/components/burnerwallet/SettingsDrawer";
 import { Address, Balance } from "~~/components/scaffold-eth";
-import { useAutoConnect } from "~~/hooks/scaffold-eth";
+import { SCAFFOLD_CHAIN_ID_STORAGE_KEY, useAutoConnect } from "~~/hooks/scaffold-eth";
 import { getTargetNetworks } from "~~/utils/scaffold-eth";
 
 const networks = getTargetNetworks();
@@ -18,8 +19,13 @@ const networks = getTargetNetworks();
 export const Header = () => {
   useAutoConnect();
 
+  const setChainId = useLocalStorage<number>(SCAFFOLD_CHAIN_ID_STORAGE_KEY, networks[0].id)[1];
   const { address: connectedAddress } = useAccount();
-  const { switchNetwork } = useSwitchNetwork();
+  const { switchNetwork } = useSwitchNetwork({
+    onSuccess(data) {
+      setChainId(data.id);
+    },
+  });
   const { chain } = useNetwork();
 
   return (

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -7,6 +7,7 @@ import { getTargetNetworks } from "~~/utils/scaffold-eth";
 
 const SCAFFOLD_WALLET_STORAGE_KEY = "scaffoldEth2.wallet";
 const WAGMI_WALLET_STORAGE_KEY = "wagmi.wallet";
+export const SCAFFOLD_CHAIN_ID_STORAGE_KEY = "scaffoldEth2.chainId";
 
 // ID of the SAFE connector instance
 const SAFE_ID = "safe";
@@ -61,6 +62,7 @@ export const useAutoConnect = (): void => {
   const [walletId, setWalletId] = useLocalStorage<string>(SCAFFOLD_WALLET_STORAGE_KEY, wagmiWalletValue ?? "", {
     initializeWithValue: false,
   });
+  const savedChainId = useReadLocalStorage<number>(SCAFFOLD_CHAIN_ID_STORAGE_KEY);
   const connectState = useConnect();
   useAccount({
     onConnect({ connector }) {
@@ -73,10 +75,14 @@ export const useAutoConnect = (): void => {
   });
 
   useEffectOnce(() => {
-    const initialConnector = getInitialConnector(getTargetNetworks()[0], walletId, connectState.connectors);
+    const targetNetwork = savedChainId
+      ? getTargetNetworks().find(n => n.id === savedChainId) ?? getTargetNetworks()[0]
+      : getTargetNetworks()[0];
+
+    const initialConnector = getInitialConnector(targetNetwork, walletId, connectState.connectors);
 
     if (initialConnector?.connector) {
-      connectState.connect({ connector: initialConnector.connector, chainId: initialConnector.chainId });
+      connectState.connect({ connector: initialConnector.connector, chainId: targetNetwork.id });
     }
   });
 };


### PR DESCRIPTION
When the user switches networks, the chainId is saved to localStorage to use the same network if the user reloads or returns to the app.

closes #19 