### PR TITLE
fix: Clears out the Send Drawer on transaction success

### DIFF
--- a/packages/nextjs/components/burnerwallet/SendDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/SendDrawer.tsx
@@ -43,9 +43,10 @@ export const SendDrawer = ({ address }: SendDrawerProps) => {
     if (isConfirmed && transactionData) {
       setSending(false);
       setAmount("");
+      setToAddress("");
       notification.success("Sent! " + transactionData.hash);
     }
-  }, [isConfirmed, transactionData]);
+  }, [isConfirmed, setToAddress, transactionData]);
 
   const sendDisabled =
     sending ||


### PR DESCRIPTION
## Description

- Sets the `toAddress` to empty string once the send transaction completes.
- Removes the unnecessary `Sent!` plain text message at the bottom of the drawer.
- Moves the `Sending...` text into the button and show a loading spinner when sending.