### PR TITLE
fix: Add reset after send transaction hook confirms

### DIFF
--- a/packages/nextjs/components/burnerwallet/SendDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/SendDrawer.tsx
@@ -28,7 +28,7 @@ export const SendDrawer = ({ address }: SendDrawerProps) => {
     address,
   });
 
-  const { data: transactionData, sendTransaction } = useSendTransaction();
+  const { data: transactionData, sendTransaction, reset } = useSendTransaction();
 
   const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransaction({
     hash: transactionData?.hash,
@@ -44,9 +44,10 @@ export const SendDrawer = ({ address }: SendDrawerProps) => {
       setSending(false);
       setAmount("");
       setToAddress("");
+      reset(); // resets the useSendTransaction data
       notification.success("Sent! " + transactionData.hash);
     }
-  }, [isConfirmed, setToAddress, transactionData]);
+  }, [isConfirmed, setToAddress, transactionData, reset]);
 
   const sendDisabled =
     sending ||


### PR DESCRIPTION
## Description

Expose the `reset` function from `useSendTransaction` and call it after the transaction `isConfirmed`. This will clear out the `transactionData` and reset the `useWaitForTransaction` hook