### PR TITLE
feat: Link history item transactions to block explorer

### DIFF
--- a/packages/nextjs/components/burnerwallet/History.tsx
+++ b/packages/nextjs/components/burnerwallet/History.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Address } from "../../components/scaffold-eth";
+import { TransactionHashLink } from "./TransactionHashLink";
 import { Alchemy, AssetTransfersCategory, AssetTransfersResponse, Network } from "alchemy-sdk";
 import { createPublicClient, hexToBigInt, http } from "viem";
 import * as chains from "viem/chains";
@@ -20,6 +20,7 @@ type HistoryItem = {
   address: string;
   value: number;
   asset: string | null;
+  hash: `0x${string}`;
   type: "sent" | "received";
   category: AssetTransfersCategory;
   categoryLabel: string;
@@ -118,6 +119,7 @@ export const History = ({ address }: { address: string }) => {
             address: item.to,
             value: item.value,
             asset: item.asset,
+            hash: item.hash,
             type: "sent",
             category: item.category,
             categoryLabel: item.category === AssetTransfersCategory.EXTERNAL ? "Sent" : categoryToLabel[item.category],
@@ -138,6 +140,7 @@ export const History = ({ address }: { address: string }) => {
             address: item.from,
             value: item.value,
             asset: item.asset,
+            hash: item.hash,
             type: "received",
             category: item.category,
             categoryLabel:
@@ -193,9 +196,7 @@ export const History = ({ address }: { address: string }) => {
                 </div>
                 <div className="grow text-left flex flex-col">
                   <p className="text-md font-medium m-0">{item.categoryLabel}</p>
-                  <div>
-                    <Address address={item.address} format="short" disableAddressLink isSimpleView size="sm" />
-                  </div>
+                  <TransactionHashLink hash={item.hash} chainId={chain?.id || 1} />
                 </div>
                 <div>
                   {item.value ? (

--- a/packages/nextjs/components/burnerwallet/History.tsx
+++ b/packages/nextjs/components/burnerwallet/History.tsx
@@ -176,7 +176,11 @@ export const History = ({ address }: { address: string }) => {
   }, [address, chain, publicClient, allCategories, alchemy]);
 
   if (isLoading) {
-    return <p className="text-center">Loading...</p>;
+    return (
+      <p className="flex items-center justify-center gap-2">
+        <span className="loading loading-spinner loading-sm"></span> Loading...
+      </p>
+    );
   }
 
   if (history.length === 0) {

--- a/packages/nextjs/components/burnerwallet/SendDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/SendDrawer.tsx
@@ -88,10 +88,10 @@ export const SendDrawer = ({ address }: SendDrawerProps) => {
                 disableMultiplyBy1e18={true}
                 onChange={value => setAmount(value.toString())}
               />
-              <p className="flex items-center justify-center m-0">
+              <div className="flex items-center justify-center m-0">
                 Balance:
                 <Balance address={address} className="text-base" />
-              </p>
+              </div>
               <button
                 className="btn btn-primary disabled:bg-primary/50 disabled:text-primary-content/50 mt-4"
                 onClick={handleSend}

--- a/packages/nextjs/components/burnerwallet/SendDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/SendDrawer.tsx
@@ -5,6 +5,7 @@ import { Address as AddressType, formatEther, parseEther } from "viem";
 import { useBalance, useSendTransaction, useWaitForTransaction } from "wagmi";
 import { PaperAirplaneIcon } from "@heroicons/react/24/outline";
 import { Drawer, DrawerContent, DrawerHeader, DrawerLine, DrawerTitle, DrawerTrigger } from "~~/components/Drawer";
+import { Balance } from "~~/components/scaffold-eth";
 import { AddressInput, IntegerInput } from "~~/components/scaffold-eth/Input";
 import { useGlobalState } from "~~/services/store/store";
 import { notification } from "~~/utils/scaffold-eth";
@@ -20,11 +21,7 @@ export const SendDrawer = ({ address }: SendDrawerProps) => {
   const [amount, setAmount] = useState<string>("");
   const [sending, setSending] = useState(false);
 
-  const {
-    data: ethBalance,
-    isError: isErrorGettingEthBalance,
-    isLoading: isLoadingGettingEthBalance,
-  } = useBalance({
+  const { data: ethBalance } = useBalance({
     address,
   });
 
@@ -80,12 +77,9 @@ export const SendDrawer = ({ address }: SendDrawerProps) => {
                 disableMultiplyBy1e18={true}
                 onChange={value => setAmount(value.toString())}
               />
-              <p className="m-0 text-center">
-                Balance:{" "}
-                {!isErrorGettingEthBalance && !isLoadingGettingEthBalance && ethBalance
-                  ? formatEther(ethBalance.value)
-                  : "0"}{" "}
-                ETH
+              <p className="flex items-center justify-center m-0">
+                Balance:
+                <Balance address={address} className="text-base" />
               </p>
               <button
                 className="btn btn-primary disabled:bg-primary/50 disabled:text-primary-content/50 mt-4"

--- a/packages/nextjs/components/burnerwallet/SendDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/SendDrawer.tsx
@@ -46,12 +46,23 @@ export const SendDrawer = ({ address }: SendDrawerProps) => {
     }
   }, [isConfirmed, setToAddress, transactionData, reset]);
 
-  const sendDisabled =
-    sending ||
-    isConfirming ||
-    !toAddress ||
-    !amount ||
-    (ethBalance && parseFloat(amount) > parseFloat(formatEther(ethBalance.value || 0n)));
+  const isInsufficientFunds = ethBalance && parseFloat(amount) > parseFloat(formatEther(ethBalance.value || 0n));
+
+  const sendDisabled = sending || isConfirming || !toAddress || !amount || isInsufficientFunds;
+
+  let buttonText = <span>Send</span>;
+
+  if (isInsufficientFunds) {
+    buttonText = <span>Insufficient Funds</span>;
+  }
+
+  if (sending && !isInsufficientFunds) {
+    buttonText = (
+      <>
+        <span className="loading loading-spinner loading-xs"></span> Sending...
+      </>
+    );
+  }
 
   return (
     <Drawer>
@@ -86,13 +97,7 @@ export const SendDrawer = ({ address }: SendDrawerProps) => {
                 onClick={handleSend}
                 disabled={sendDisabled}
               >
-                {sending ? (
-                  <>
-                    <span className="loading loading-spinner loading-xs"></span> Sending...
-                  </>
-                ) : (
-                  "Send"
-                )}
+                {buttonText}
               </button>
             </div>
           </div>

--- a/packages/nextjs/components/burnerwallet/TransactionHashLink.tsx
+++ b/packages/nextjs/components/burnerwallet/TransactionHashLink.tsx
@@ -1,0 +1,20 @@
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import { getBlockExplorerTxLink } from "~~/utils/scaffold-eth";
+
+type TransactionHashLinkProps = {
+  hash: `0x${string}`;
+  chainId: number;
+};
+
+export function TransactionHashLink({ hash, chainId }: TransactionHashLinkProps) {
+  const shortHash = hash.slice(0, 6) + "..." + hash.slice(-4);
+
+  return (
+    <p className="flex items-center gap-2 m-0">
+      {shortHash}
+      <a href={getBlockExplorerTxLink(chainId, hash)} target="_blank">
+        <ArrowTopRightOnSquareIcon className="h-4 w-4 cursor-pointer" />
+      </a>
+    </p>
+  );
+}


### PR DESCRIPTION
## Description

- Added new component `TransactionHashLink` and use it in the history list. This will link the transaction hash to the block explorer (https://github.com/BuidlGuidl/burnerwallet/issues/27)
- In the Send Drawer, use the `<Balance />` component so it's consistent with the `<Header />` (https://github.com/BuidlGuidl/burnerwallet/issues/32)
- In the Send Drawer, change button text to `Insufficient Funds` if the wallet doesn't have enough funds (https://github.com/BuidlGuidl/burnerwallet/issues/33)