### PR TITLE
refactor: Use EtherInput in Send Drawer

### DIFF
--- a/packages/nextjs/components/burnerwallet/History.tsx
+++ b/packages/nextjs/components/burnerwallet/History.tsx
@@ -39,7 +39,7 @@ export const History = ({ chainId, isLoading, history }: HistoryProps) => {
                   {item.value ? (
                     <>
                       {item.type === "sent" ? "-" : "+"}
-                      {item.value} {item.asset}
+                      {item.value.toFixed(4)} {item.asset}
                     </>
                   ) : (
                     "0"

--- a/packages/nextjs/components/burnerwallet/SendDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/SendDrawer.tsx
@@ -5,8 +5,8 @@ import { Address as AddressType, formatEther, parseEther } from "viem";
 import { useBalance, useNetwork, useSendTransaction, useWaitForTransaction } from "wagmi";
 import { PaperAirplaneIcon } from "@heroicons/react/24/outline";
 import { Drawer, DrawerContent, DrawerHeader, DrawerLine, DrawerTitle, DrawerTrigger } from "~~/components/Drawer";
-import { Balance } from "~~/components/scaffold-eth";
-import { AddressInput, IntegerInput } from "~~/components/scaffold-eth/Input";
+import { Balance, EtherInput } from "~~/components/scaffold-eth";
+import { AddressInput } from "~~/components/scaffold-eth/Input";
 import { useGlobalState } from "~~/services/store/store";
 import { notification } from "~~/utils/scaffold-eth";
 
@@ -105,12 +105,7 @@ export const SendDrawer = ({ address, updateHistory }: SendDrawerProps) => {
                 placeholder="Enter recipient ENS or 0xAddress"
                 onChange={value => setToAddress(value)}
               />
-              <IntegerInput
-                value={amount}
-                placeholder="0.00 ETH"
-                disableMultiplyBy1e18={true}
-                onChange={value => setAmount(value.toString())}
-              />
+              <EtherInput value={amount} placeholder="0.00 ETH" onChange={value => setAmount(value.toString())} />
             </div>
             <div className="flex flex-col gap-8 mt-2 px-6 pb-12">
               <div className="flex items-center justify-center m-0 text-lg">

--- a/packages/nextjs/components/burnerwallet/SendDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/SendDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Address as AddressType, formatEther, parseEther } from "viem";
+import { Address as AddressType, formatEther, isAddress, parseEther } from "viem";
 import { useBalance, useNetwork, useSendTransaction, useWaitForTransaction } from "wagmi";
 import { PaperAirplaneIcon } from "@heroicons/react/24/outline";
 import { Drawer, DrawerContent, DrawerHeader, DrawerLine, DrawerTitle, DrawerTrigger } from "~~/components/Drawer";
@@ -18,6 +18,7 @@ type SendDrawerProps = {
 export const SendDrawer = ({ address, updateHistory }: SendDrawerProps) => {
   const toAddress = useGlobalState(state => state.sendEthToAddress);
   const setToAddress = useGlobalState(state => state.setSendEthToAddress);
+  const isValidAddress = isAddress(toAddress);
   const { chain } = useNetwork();
 
   const [amount, setAmount] = useState<string>("");
@@ -71,12 +72,16 @@ export const SendDrawer = ({ address, updateHistory }: SendDrawerProps) => {
   const isInsufficientFunds =
     isIdle && ethBalance && parseFloat(amount) > parseFloat(formatEther(ethBalance.value || 0n));
 
-  const sendDisabled = sending || isConfirming || !toAddress || !amount || isInsufficientFunds;
+  const sendDisabled = sending || isConfirming || !isValidAddress || !amount || isInsufficientFunds;
 
   let buttonText = <span>Send</span>;
 
   if (isInsufficientFunds) {
     buttonText = <span>Insufficient Funds</span>;
+  }
+
+  if (toAddress && !isValidAddress) {
+    buttonText = <span>Enter a valid address or ENS</span>;
   }
 
   if (sending && !isInsufficientFunds) {

--- a/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
@@ -121,11 +121,11 @@ export const EtherInput = ({
           data-tip="Unable to fetch price"
         >
           <button
-            className="btn btn-primary h-[2.2rem] min-h-[2.2rem]"
+            className="btn btn-sm btn-ghost mt-2"
             onClick={toggleMode}
             disabled={!internalUsdMode && !nativeCurrencyPrice}
           >
-            <ArrowsRightLeftIcon className="h-3 w-3 cursor-pointer" aria-hidden="true" />
+            <ArrowsRightLeftIcon className="h-6 w-6 cursor-pointer" aria-hidden="true" />
           </button>
         </div>
       }

--- a/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
@@ -110,7 +110,7 @@ export const EtherInput = ({
       placeholder={placeholder}
       onChange={handleChangeNumber}
       disabled={disabled}
-      prefix={<span className="pl-4 -mr-2 text-accent self-center">{internalUsdMode ? "$" : "Ξ"}</span>}
+      prefix={<span className="pl-4 -mr-2 text-accent font-mono self-center">{internalUsdMode ? "$" : "Ξ"}</span>}
       suffix={
         <div
           className={`${


### PR DESCRIPTION
## Description

Use the `EtherInput` component in the send drawer. Also added a `toFixed(4)` to the values that show up in the history list, so that they don't overflow

<img width="578" alt="Screenshot 2024-04-24 at 10 22 20 AM" src="https://github.com/BuidlGuidl/burnerwallet/assets/716376/dc0da787-3b70-47a4-96ce-bfad79acef2e">
