### PR TITLE
refactor: UX improvements

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -52,7 +52,7 @@ export const Header = ({ updateHistory }: { updateHistory: () => void }) => {
         <div className="text-white">
           <Address address={connectedAddress} disableAddressLink size="base" format="short" />
           <div className="mt-8 mb-10 flex justify-center">
-            <Balance className="text-6xl" address={connectedAddress} usdMode={true} />
+            <Balance className="text-6xl" address={connectedAddress} usdMode />
           </div>
         </div>
         <div className="flex items-center justify-center gap-6 mt-6">

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -50,9 +50,9 @@ export const Header = ({ updateHistory }: { updateHistory: () => void }) => {
           />
         </div>
         <div className="text-white">
-          <Address address={connectedAddress} disableAddressLink size="xl" format="short" />
-          <div className="mt-4 flex justify-center">
-            <Balance className="text-2xl" address={connectedAddress} />
+          <Address address={connectedAddress} disableAddressLink size="base" format="short" />
+          <div className="mt-6 mb-8 flex justify-center">
+            <Balance className="text-5xl" address={connectedAddress} usdMode={true} />
           </div>
         </div>
         <div className="flex items-center justify-center gap-6 mt-6">

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -51,8 +51,8 @@ export const Header = ({ updateHistory }: { updateHistory: () => void }) => {
         </div>
         <div className="text-white">
           <Address address={connectedAddress} disableAddressLink size="base" format="short" />
-          <div className="mt-6 mb-8 flex justify-center">
-            <Balance className="text-5xl" address={connectedAddress} usdMode={true} />
+          <div className="mt-8 mb-10 flex justify-center">
+            <Balance className="text-6xl" address={connectedAddress} usdMode={true} />
           </div>
         </div>
         <div className="flex items-center justify-center gap-6 mt-6">

--- a/packages/nextjs/components/burnerwallet/QrCodeReader.tsx
+++ b/packages/nextjs/components/burnerwallet/QrCodeReader.tsx
@@ -24,7 +24,7 @@ const QrCodeReader = () => {
   return (
     <>
       {isQrReaderOpen && (
-        <div className="max-w-[90%] w-[300px] h-[300px] fixed top-0 left-0 right-0 bottom-0 m-auto z-50">
+        <div className="max-w-[90%] w-[300px] h-[300px] fixed top-0 left-0 right-0 bottom-0 m-auto z-[100]">
           <ReactQrReader
             // @ts-ignore
             onScan={(result: string) => {
@@ -34,12 +34,12 @@ const QrCodeReader = () => {
               }
             }}
             onError={(error: any) => console.log(error)}
-            style={{ width: "100%" }}
+            style={{ width: "100%", zIndex: 100 }}
           />
         </div>
       )}
       {isQrReaderOpen && (
-        <div className="fixed inset-0 z-10 bg-white bg-opacity-80" onClick={() => setIsQrReaderOpen(false)} />
+        <div className="fixed inset-0 z-[99] bg-black bg-opacity-80" onClick={() => setIsQrReaderOpen(false)} />
       )}
     </>
   );

--- a/packages/nextjs/components/burnerwallet/QrCodeReader.tsx
+++ b/packages/nextjs/components/burnerwallet/QrCodeReader.tsx
@@ -9,13 +9,14 @@ const ReactQrReader = dynamic(() => import("react-qr-reader"), { ssr: false });
 const QrCodeReader = () => {
   const isQrReaderOpen = useGlobalState(state => state.isQrReaderOpen);
   const setIsQrReaderOpen = useGlobalState(state => state.setIsQrReaderOpen);
+  const setIsSendDrawerOpen = useGlobalState(state => state.setIsSendDrawerOpen);
   const setToAddress = useGlobalState(state => state.setSendEthToAddress);
 
   const handleScanRead = (result: string) => {
     if (isAddress(result)) {
       setToAddress(result);
       setIsQrReaderOpen(false);
-      document.getElementById("send-eth-drawer")?.click();
+      setIsSendDrawerOpen(true);
     } else {
       notification.error("Invalid address");
     }

--- a/packages/nextjs/components/burnerwallet/SendDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/SendDrawer.tsx
@@ -110,12 +110,12 @@ export const SendDrawer = ({ address, updateHistory }: SendDrawerProps) => {
                 placeholder="Enter recipient ENS or 0xAddress"
                 onChange={value => setToAddress(value)}
               />
-              <EtherInput value={amount} placeholder="0.00 ETH" onChange={value => setAmount(value.toString())} />
+              <EtherInput value={amount} placeholder="0.00" onChange={value => setAmount(value.toString())} usdMode />
             </div>
             <div className="flex flex-col gap-8 mt-2 px-6 pb-12">
               <div className="flex items-center justify-center m-0 text-lg">
                 Balance:
-                <Balance address={address} className="text-lg" />
+                <Balance address={address} className="text-lg" usdMode />
               </div>
               {!error && (
                 <button

--- a/packages/nextjs/components/burnerwallet/SendDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/SendDrawer.tsx
@@ -18,12 +18,13 @@ type SendDrawerProps = {
 export const SendDrawer = ({ address, updateHistory }: SendDrawerProps) => {
   const toAddress = useGlobalState(state => state.sendEthToAddress);
   const setToAddress = useGlobalState(state => state.setSendEthToAddress);
+  const isSendDrawerOpen = useGlobalState(state => state.isSendDrawerOpen);
+  const setIsSendDrawerOpen = useGlobalState(state => state.setIsSendDrawerOpen);
   const isValidAddress = isAddress(toAddress);
   const { chain } = useNetwork();
 
   const [amount, setAmount] = useState<string>("");
   const [sending, setSending] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
 
   const { data: ethBalance } = useBalance({
     address,
@@ -65,9 +66,9 @@ export const SendDrawer = ({ address, updateHistory }: SendDrawerProps) => {
       setAmount("");
       setToAddress("");
       reset(); // resets the useSendTransaction data
-      setIsOpen(false);
+      setIsSendDrawerOpen(false);
     }
-  }, [isConfirmed, setToAddress, transactionData, reset, updateHistory]);
+  }, [isConfirmed, reset, setIsSendDrawerOpen, setToAddress, transactionData, updateHistory]);
 
   const isInsufficientFunds =
     isIdle && ethBalance && parseFloat(amount) > parseFloat(formatEther(ethBalance.value || 0n));
@@ -93,7 +94,7 @@ export const SendDrawer = ({ address, updateHistory }: SendDrawerProps) => {
   }
 
   return (
-    <Drawer open={isOpen} onOpenChange={setIsOpen}>
+    <Drawer open={isSendDrawerOpen} onOpenChange={setIsSendDrawerOpen}>
       <DrawerTrigger id="send-eth-drawer" className="btn btn-neutral bg-white/50">
         <PaperAirplaneIcon className="w-6" /> Send
       </DrawerTrigger>

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -54,8 +54,8 @@ export const Address = ({ address, disableAddressLink, isSimpleView, format, siz
   // Skeleton UI
   if (!checkSumAddress) {
     return (
-      <div className="animate-pulse flex flex-col items-center justify-center gap-4">
-        {!isSimpleView && <div className="rounded-full bg-slate-300 h-16 w-16"></div>}
+      <div className="animate-pulse flex flex-col items-center justify-center gap-2">
+        {!isSimpleView && <div className="rounded-full bg-slate-300 h-10 w-10"></div>}
         <div className="flex items-center space-y-6">
           <div className="h-6 w-48 bg-slate-300 rounded"></div>
         </div>
@@ -77,12 +77,12 @@ export const Address = ({ address, disableAddressLink, isSimpleView, format, siz
   }
 
   const containerClass = isSimpleView ? "" : "flex flex-col items-center";
-  const addressContainerClass = isSimpleView ? "flex items-center" : "flex items-center mt-4";
-  const addressClass = isSimpleView ? `text-${size}` : `ml-1.5 text-${size} font-normal`;
+  const addressContainerClass = isSimpleView ? "flex items-center" : "flex items-center mt-1";
+  const addressClass = isSimpleView ? `text-${size}` : `text-${size} font-normal`;
 
   return (
     <div className={containerClass}>
-      {!isSimpleView && <BlockieAvatar address={checkSumAddress} ensImage={ensAvatar} size={60} />}
+      {!isSimpleView && <BlockieAvatar address={checkSumAddress} ensImage={ensAvatar} size={40} />}
       <div className={addressContainerClass}>
         {disableAddressLink ? (
           <span className={addressClass}>{displayAddress}</span>
@@ -97,7 +97,7 @@ export const Address = ({ address, disableAddressLink, isSimpleView, format, siz
         )}
 
         {addressCopied ? (
-          <CheckCircleIcon className="ml-1.5 text-xl font-normal h-6 w-6 cursor-pointer" aria-hidden="true" />
+          <CheckCircleIcon className="ml-1.5 text-xl font-normal h-4 w-4 cursor-pointer" aria-hidden="true" />
         ) : (
           <CopyToClipboard
             text={checkSumAddress}
@@ -108,7 +108,7 @@ export const Address = ({ address, disableAddressLink, isSimpleView, format, siz
               }, 800);
             }}
           >
-            <DocumentDuplicateIcon className="ml-2 h-6 w-6 cursor-pointer" aria-hidden="true" />
+            <DocumentDuplicateIcon className="ml-2 h-4 w-4 cursor-pointer" aria-hidden="true" />
           </CopyToClipboard>
         )}
 
@@ -118,7 +118,7 @@ export const Address = ({ address, disableAddressLink, isSimpleView, format, siz
           href={blockExplorerAddressLink}
           rel="noopener noreferrer"
         >
-          <ArrowTopRightOnSquareIcon className="h-6 w-6 cursor-pointer" aria-hidden="true" />
+          <ArrowTopRightOnSquareIcon className="h-4 w-4 cursor-pointer" aria-hidden="true" />
         </a>
       </div>
     </div>

--- a/packages/nextjs/components/scaffold-eth/Balance.tsx
+++ b/packages/nextjs/components/scaffold-eth/Balance.tsx
@@ -14,10 +14,10 @@ type BalanceProps = {
 /**
  * Display (ETH & USD) balance of an ETH address.
  */
-export const Balance = ({ address, className = "", usdMode }: BalanceProps) => {
+export const Balance = ({ address, className = "", usdMode = false }: BalanceProps) => {
   const { targetNetwork } = useTargetNetwork();
   const { balance, price, isError, isLoading } = useAccountBalance(address);
-  const [displayUsdMode, setDisplayUsdMode] = useState(price > 0 ? Boolean(usdMode) : false);
+  const [displayUsdMode, setDisplayUsdMode] = useState(Boolean(usdMode));
 
   const toggleBalanceMode = () => {
     if (price > 0) {

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -4,6 +4,8 @@ import { useDebounce } from "usehooks-ts";
 import { Address, isAddress } from "viem";
 import { useEnsAddress, useEnsAvatar, useEnsName } from "wagmi";
 import { CommonInputProps, InputBase, isENS } from "~~/components/scaffold-eth";
+import ScanIcon from "~~/icons/ScanIcon";
+import { useGlobalState } from "~~/services/store/store";
 
 /**
  * Address input with ENS name resolution
@@ -17,6 +19,8 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
 
   // If the user changes the input after an ENS name is already resolved, we want to remove the stale result
   const settledValue = isDebouncedValueLive ? debouncedValue : undefined;
+
+  const setIsQrReaderOpen = useGlobalState(state => state.setIsQrReaderOpen);
 
   const { data: ensAddress, isLoading: isEnsAddressLoading } = useEnsAddress({
     name: settledValue,
@@ -70,22 +74,30 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
         <img alt={`${ensAddress} avatar`} className={avatarStyles} src={ensAvatar} width={96} height={96} />
       )}
       {!value && !ensAvatar && <div className={`${avatarStyles} w-24 h-24 bg-slate-300`}></div>}
-      <div className="w-full">
-        <InputBase<Address>
-          name={name}
-          placeholder={placeholder}
-          error={ensAddress === null}
-          value={value as Address}
-          onChange={handleChange}
-          disabled={isEnsAddressLoading || isEnsNameLoading || disabled}
-          prefix={
-            ensName && (
-              <div className="flex bg-accent text-accent-content rounded-l-md items-center">
-                <span className="px-2">{enteredEnsName ?? ensName}</span>
-              </div>
-            )
-          }
-        />
+      <div className="flex items-center justify-between gap-4 w-full">
+        <div className="flex-1">
+          <InputBase<Address>
+            name={name}
+            placeholder={placeholder}
+            error={ensAddress === null}
+            value={value as Address}
+            onChange={handleChange}
+            disabled={isEnsAddressLoading || isEnsNameLoading || disabled}
+            prefix={
+              ensName && (
+                <div className="flex bg-accent text-accent-content rounded-l-md items-center">
+                  <span className="px-2">{enteredEnsName ?? ensName}</span>
+                </div>
+              )
+            }
+          />
+        </div>
+        <button
+          className="shrink-0 w-12 h-12 bg-accent text-accent-content rounded-lg"
+          onClick={() => setIsQrReaderOpen(true)}
+        >
+          <ScanIcon width="28" height="28" className="mx-auto" />
+        </button>
       </div>
     </div>
   );

--- a/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
@@ -71,6 +71,11 @@ export const EtherInput = ({
     return newDisplayValue;
   }, [nativeCurrencyPrice, transitoryDisplayValue, internalUsdMode, value]);
 
+  const oppositeDisplayValue = useMemo(() => {
+    const newDisplayValue = etherValueToDisplayValue(!internalUsdMode, value, nativeCurrencyPrice);
+    return newDisplayValue;
+  }, [nativeCurrencyPrice, internalUsdMode, value]);
+
   const handleChangeNumber = (newValue: string) => {
     if (newValue && !SIGNED_NUMBER_REGEX.test(newValue)) {
       return;
@@ -104,31 +109,36 @@ export const EtherInput = ({
   };
 
   return (
-    <InputBase
-      name={name}
-      value={displayValue}
-      placeholder={placeholder}
-      onChange={handleChangeNumber}
-      disabled={disabled}
-      prefix={<span className="pl-4 -mr-2 text-accent font-mono self-center">{internalUsdMode ? "$" : "Ξ"}</span>}
-      suffix={
-        <div
-          className={`${
-            nativeCurrencyPrice > 0
-              ? ""
-              : "tooltip tooltip-secondary before:content-[attr(data-tip)] before:right-[-10px] before:left-auto before:transform-none"
-          }`}
-          data-tip="Unable to fetch price"
-        >
-          <button
-            className="btn btn-sm btn-ghost mt-2"
-            onClick={toggleMode}
-            disabled={!internalUsdMode && !nativeCurrencyPrice}
+    <div>
+      <InputBase
+        name={name}
+        value={displayValue}
+        placeholder={placeholder}
+        onChange={handleChangeNumber}
+        disabled={disabled}
+        prefix={<span className="pl-4 -mr-2 text-accent font-mono self-center">{internalUsdMode ? "$" : "Ξ"}</span>}
+        suffix={
+          <div
+            className={`${
+              nativeCurrencyPrice > 0
+                ? ""
+                : "tooltip tooltip-secondary before:content-[attr(data-tip)] before:right-[-10px] before:left-auto before:transform-none"
+            }`}
+            data-tip="Unable to fetch price"
           >
-            <ArrowsRightLeftIcon className="h-6 w-6 cursor-pointer" aria-hidden="true" />
-          </button>
-        </div>
-      }
-    />
+            <button
+              className="btn btn-sm btn-ghost mt-2"
+              onClick={toggleMode}
+              disabled={!internalUsdMode && !nativeCurrencyPrice}
+            >
+              <ArrowsRightLeftIcon className="h-6 w-6 cursor-pointer" aria-hidden="true" />
+            </button>
+          </div>
+        }
+      />
+      <p className="mt-2 mb-0 ml-5 text-left text-sm opacity-50">
+        <span className="font-mono">{internalUsdMode ? "Ξ" : "$"}</span> {oppositeDisplayValue}
+      </p>
+    </div>
   );
 };

--- a/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
@@ -136,8 +136,12 @@ export const EtherInput = ({
           </div>
         }
       />
-      <p className="mt-2 mb-0 ml-5 text-left text-sm opacity-50">
-        <span className="font-mono">{internalUsdMode ? "Ξ" : "$"}</span> {oppositeDisplayValue}
+      <p className="mt-2 mb-0 ml-5 text-left text-sm opacity-50 h-5">
+        {value && (
+          <span>
+            <span className="font-mono">{internalUsdMode ? "Ξ" : "$"}</span> {oppositeDisplayValue}
+          </span>
+        )}
       </p>
     </div>
   );

--- a/packages/nextjs/services/store/store.ts
+++ b/packages/nextjs/services/store/store.ts
@@ -20,6 +20,8 @@ type GlobalState = {
   setIsQrReaderOpen: (newValue: boolean) => void;
   sendEthToAddress: string;
   setSendEthToAddress: (newValue: string) => void;
+  isSendDrawerOpen: boolean;
+  setIsSendDrawerOpen: (newValue: boolean) => void;
 };
 
 export const useGlobalState = create<GlobalState>(set => ({
@@ -31,4 +33,6 @@ export const useGlobalState = create<GlobalState>(set => ({
   setIsQrReaderOpen: (newValue: boolean): void => set(() => ({ isQrReaderOpen: newValue })),
   sendEthToAddress: "",
   setSendEthToAddress: (newValue: string): void => set(() => ({ sendEthToAddress: newValue })),
+  isSendDrawerOpen: false,
+  setIsSendDrawerOpen: (newValue: boolean): void => set(() => ({ isSendDrawerOpen: newValue })),
 }));


### PR DESCRIPTION
## Description

- Style adjustments to make the `Balance` bigger and the `Address` smaller
- Default balance and inputs to USD
- Add the `oppositeDisplayValue` to the `EtherInput` component
- Add `isSendDrawerOpen` to the global state, so it can be better controlled after QR code scanning
- Add a scan button to the `AddressInput` component

<img width="483" alt="Screenshot 2024-05-29 at 4 27 59 PM" src="https://github.com/BuidlGuidl/burnerwallet/assets/716376/a4b49f8d-3f4b-400f-b3e0-69c325da64cc">

<img width="483" alt="Screenshot 2024-05-29 at 4 28 38 PM" src="https://github.com/BuidlGuidl/burnerwallet/assets/716376/bfc24e32-0a7f-42ad-88b9-58b421125826">
