### PR TITLE
Add switch network drawer

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { RandomLoadingBackground } from "./RandomLoadingBackground";
 import { WalletConnectProposalDrawer } from "./burnerwallet/WalletConnectProposalDrawer";
+import { WalletConnectSwitchNetworkDrawer } from "./burnerwallet/WalletConnectSwitchNetworkDrawer";
 import { WalletConnectTransactionDrawer } from "./burnerwallet/WalletConnectTransactionDrawer";
 import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
 import { useLocalStorage } from "usehooks-ts";
@@ -88,6 +89,7 @@ export const Header = ({ isGenerateWalletLoading, showIntro, updateHistory }: He
           <WalletConnectDrawer />
           <WalletConnectProposalDrawer />
           <WalletConnectTransactionDrawer />
+          <WalletConnectSwitchNetworkDrawer />
         </div>
       </div>
     </div>

--- a/packages/nextjs/components/burnerwallet/WalletConnectSwitchNetworkDrawer.tsx
+++ b/packages/nextjs/components/burnerwallet/WalletConnectSwitchNetworkDrawer.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+import { Drawer, DrawerContent, DrawerHeader, DrawerLine, DrawerTitle } from "~~/components/Drawer";
+import { useWalletConnectManager } from "~~/hooks/useWalletConnectManager";
+
+export const WalletConnectSwitchNetworkDrawer = () => {
+  const {
+    loading,
+    isNetworkSwitchOpen,
+    setIsNetworkSwitchOpen,
+    onNetworkSwitchAccept,
+    onNetworkSwitchReject,
+    networkFromRequest,
+  } = useWalletConnectManager();
+
+  return (
+    <Drawer open={isNetworkSwitchOpen} onOpenChange={setIsNetworkSwitchOpen}>
+      <DrawerContent>
+        <DrawerLine />
+        <DrawerHeader>
+          <DrawerTitle className="mt-1 text-2xl">WalletConnect Switch Network</DrawerTitle>
+        </DrawerHeader>
+        <div>
+          <div className="flex flex-col items-center px-2">Do you want to switch to {networkFromRequest?.name}?</div>
+          <div className="max-w-lg mx-auto m-8 text-center">
+            <button className="btn btn-secondary mr-8" disabled={loading} onClick={onNetworkSwitchReject}>
+              Reject
+            </button>
+            <button className="btn btn-primary" disabled={loading} onClick={onNetworkSwitchAccept}>
+              Accept
+            </button>
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/packages/nextjs/services/store/store.ts
+++ b/packages/nextjs/services/store/store.ts
@@ -27,6 +27,8 @@ type GlobalState = {
   setIsWalletConnectInitialized: (newValue: boolean) => void;
   isWalletConnectOpen: boolean;
   setIsWalletConnectOpen: (newValue: boolean) => void;
+  isTransactionConfirmOpen: boolean;
+  setIsTransactionConfirmOpen: (newValue: boolean) => void;
   walletConnectSession: SessionTypes.Struct | null;
   setWalletConnectSession: (newValue: SessionTypes.Struct | null) => void;
   isSendDrawerOpen: boolean;
@@ -48,6 +50,8 @@ export const useGlobalState = create<GlobalState>(set => ({
   setIsWalletConnectInitialized: (newValue: boolean): void => set(() => ({ isWalletConnectInitialized: newValue })),
   isWalletConnectOpen: false,
   setIsWalletConnectOpen: (newValue: boolean): void => set(() => ({ isWalletConnectOpen: newValue })),
+  isTransactionConfirmOpen: false,
+  setIsTransactionConfirmOpen: (newValue: boolean): void => set(() => ({ isTransactionConfirmOpen: newValue })),
   walletConnectSession: null,
   setWalletConnectSession: (newValue: SessionTypes.Struct | null): void =>
     set(() => ({ walletConnectSession: newValue })),


### PR DESCRIPTION
Added the switch network feature as a drawer.

![localhost_3000_ (51)](https://github.com/BuidlGuidl/burnerwallet/assets/466652/568d9859-e447-468c-9661-6d661d32f2a4)

But I'm having an issue when the "Warning: Your Burner Wallet Has Funds!" is shown after switching the current network from this drawer. When you click the "Close Warning" button, the drawer confirms the transaction is closed.

![warning](https://github.com/BuidlGuidl/burnerwallet/assets/466652/5475b8e0-ec1f-4cce-8d52-f7d9fe1ea03a)

Tried to set the modal property from the Drawer to false, so the Confirmation Drawer does not close when the user interacts outside the drawer, but this doesn't work when the user interacts with a form component, like when the user clicks the "Close Warning" button. 

I will check the Drawer issues if this is a reported bug, but maybe @ChangoMan has some tips about it since he implemented the drawers inside our project. It can be reproduced by adding modal false to the send drawer, the drawer will not close if you click outside the drawer but it gets closed when you click the networks select.