### PR TITLE
refactor: Use Radix UI Dialog as the Balance Warning Modal

### DIFF
--- a/packages/nextjs/components/Dialog.tsx
+++ b/packages/nextjs/components/Dialog.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+// import { XMarkIcon } from "@heroicons/react/24/outline";
+import { cn } from "~~/utils/cn";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-base-100 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {/* <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <XMarkIcon className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close> */}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm", className)} {...props} />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/packages/nextjs/components/Dialog.tsx
+++ b/packages/nextjs/components/Dialog.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-// import { XMarkIcon } from "@heroicons/react/24/outline";
 import { cn } from "~~/utils/cn";
 
 const Dialog = DialogPrimitive.Root;
@@ -43,10 +42,6 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      {/* <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <XMarkIcon className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close> */}
     </DialogPrimitive.Content>
   </DialogPortal>
 ));

--- a/packages/nextjs/components/burnerwallet/BalanceWarningModal.tsx
+++ b/packages/nextjs/components/burnerwallet/BalanceWarningModal.tsx
@@ -46,7 +46,14 @@ export const BalanceWarningModal = () => {
 
   return (
     <Dialog open={isWarningModalOpen} onOpenChange={setIsWarningModalOpen}>
-      <DialogContent>
+      <DialogContent
+        onInteractOutside={e => {
+          e.preventDefault();
+        }}
+        onEscapeKeyDown={e => {
+          e.preventDefault();
+        }}
+      >
         <div>
           <div role="alert" className="alert alert-warning mb-1">
             <ExclamationTriangleIcon className="w-6 h-6" />

--- a/packages/nextjs/components/burnerwallet/BalanceWarningModal.tsx
+++ b/packages/nextjs/components/burnerwallet/BalanceWarningModal.tsx
@@ -5,6 +5,7 @@ import { CopyPrivateKey } from "./CopyPrivateKey";
 import { useLocalStorage } from "usehooks-ts";
 import { useAccount } from "wagmi";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { Dialog, DialogContent } from "~~/components/Dialog";
 import { useAccountBalance } from "~~/hooks/scaffold-eth";
 
 const BURNER_WALLET_HIDE_BALANCE_STORAGE_KEY = "scaffoldEth2.hideBalanceWarning";
@@ -44,16 +45,9 @@ export const BalanceWarningModal = () => {
   }
 
   return (
-    <>
-      <input
-        readOnly
-        type="checkbox"
-        id="balance_warning_modal"
-        className="modal-toggle"
-        checked={isWarningModalOpen}
-      />
-      <div className="modal" role="dialog">
-        <div className="modal-box">
+    <Dialog open={isWarningModalOpen} onOpenChange={setIsWarningModalOpen}>
+      <DialogContent>
+        <div>
           <div role="alert" className="alert alert-warning mb-1">
             <ExclamationTriangleIcon className="w-6 h-6" />
             <span>
@@ -79,7 +73,7 @@ export const BalanceWarningModal = () => {
             </button>
           </div>
         </div>
-      </div>
-    </>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@ethersproject/providers": "^5.7.2",
     "@heroicons/react": "^2.0.11",
+    "@radix-ui/react-dialog": "^1.0.5",
     "@rainbow-me/rainbowkit": "1.3.5",
     "@tanstack/react-query": "^5.44.0",
     "@uniswap/sdk-core": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,7 +1913,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dialog@npm:^1.0.4":
+"@radix-ui/react-dialog@npm:^1.0.4, @radix-ui/react-dialog@npm:^1.0.5":
   version: 1.0.5
   resolution: "@radix-ui/react-dialog@npm:1.0.5"
   dependencies:
@@ -2332,6 +2332,7 @@ __metadata:
   dependencies:
     "@ethersproject/providers": ^5.7.2
     "@heroicons/react": ^2.0.11
+    "@radix-ui/react-dialog": ^1.0.5
     "@rainbow-me/rainbowkit": 1.3.5
     "@tanstack/react-query": ^5.44.0
     "@trivago/prettier-plugin-sort-imports": ^4.1.1


### PR DESCRIPTION
## Description

Replaces the Daisy UI modal with Radix UI's dialog, for the Balance Warning Modal. There seems to be weird UX behaviors when mixing Daisy UI modals with the Drawer component we have.

Since the Drawer component is using Radix dialog under the hood, this should resolve those weird issues.

### Testing

To test the drawer and modal together, I am going into `nextjs/services/store/store.ts` and setting `isSendDrawerOpen` to be `true` initially.

When I have a balance, both the send drawer and warning modal will show up. I can interact and close the warning modal and the send drawer stays open. Hopefully this will also fix the issues in https://github.com/BuidlGuidl/burnerwallet/pull/71